### PR TITLE
Implement adaptive engine depth and timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,6 +194,10 @@
                         <span class="indicator-label">Profundidad Adaptativa</span>
                         <span class="indicator-value" id="depthValue">--</span>
                     </div>
+                    <div class="indicator" id="timeIndicator">
+                        <span class="indicator-label">Tiempo Previsto</span>
+                        <span class="indicator-value" id="timeValue">--</span>
+                    </div>
                 </div>
             </div>
 
@@ -234,6 +238,7 @@
                             <div class="stats-display">
                                 <span id="engineStats" title="Profundidad de búsqueda y velocidad">--</span>
                                 <span id="memoryStats" title="Uso de memoria JavaScript">--</span>
+                                <span id="analysisTimer" title="Tiempo de análisis">--</span>
                             </div>
                         </div>
 


### PR DESCRIPTION
## Summary
- display expected depth and time indicators on the UI
- show elapsed analysis time in the stats panel
- add adaptive depth and time calculation based on past evaluations
- force engine move when the planned time is reached
- keep track of evaluation history and nodes per second for adaptation

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b810a8c10832d973a54f3a89307ca