### PR TITLE
Mejoras en modo Versus CPU

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,11 +219,17 @@
                                         title="Conectar/Desconectar motor Stockfish">
                                     <i class="fas fa-plug"></i>Conectar Motor
                                 </button>
-                                <button onclick="window.chessApp.toggleAnalysis()" 
-                                        id="analysisToggleBtn" 
+                                <button onclick="window.chessApp.toggleAnalysis()"
+                                        id="analysisToggleBtn"
                                         class="btn btn-success"
                                         title="Iniciar/Detener análisis fractal">
                                     <i class="fas fa-play"></i>Analizar
+                                </button>
+                                <button onclick="window.chessApp.forceBestMove()"
+                                        id="forceMoveBtn"
+                                        class="btn btn-warning"
+                                        title="Forzar el movimiento de la mejor línea">
+                                    <i class="fas fa-forward"></i>Forzar movimiento
                                 </button>
                             </div>
                             <div id="engineStatus" class="engine-status">Motor no conectado</div>


### PR DESCRIPTION
## Summary
- deshabilitar el botón de análisis cuando se selecciona Versus CPU
- agregar botón "Forzar movimiento" y exponerlo en la API
- iniciar el análisis solo en el turno de la CPU y permitir forzarlo
- ajustar eventos del motor y controles fractales

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b8427f6ec832d9f1a3a34603509d5