### PR TITLE
Implement automatic CPU moves on bestmove

### DIFF
--- a/script.js
+++ b/script.js
@@ -849,6 +849,8 @@
         stopAnalysis();
         if (lastStats.bestMoveSan) {
             makeMove(lastStats.bestMoveSan);
+        } else {
+            makeCpuMove();
         }
     }
 
@@ -1021,7 +1023,7 @@
     function processBestMove(line) {
         const parts = line.split(' ');
         const bestMove = parts[1];
-        
+
         if (bestMove && bestMove !== '(none)') {
             lastStats.bestMove = bestMove;
             lastStats.bestMoveSan = uciToSan(bestMove);
@@ -1046,6 +1048,15 @@
             if (timerInterval) {
                 clearInterval(timerInterval);
                 timerInterval = null;
+            }
+
+            if (gameMode === 'cpu') {
+                stopAnalysis();
+                if (lastStats.bestMoveSan) {
+                    makeMove(lastStats.bestMoveSan);
+                } else {
+                    makeCpuMove();
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- call `makeMove()` in CPU mode when a best move is received
- add fallback in `forceBestMove()` to play a random move if no best move is available

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b895ff858832db200f0d9f91567da