### PR TITLE
Mejoras de diseño del analizador

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         .container {
             max-width: 1600px;
             margin: 0 auto;
-            padding: 16px;
+            padding: 8px;
             min-height: 100vh;
             display: flex;
             flex-direction: column;
@@ -47,8 +47,8 @@
             background: white;
             border: 1px solid #dee2e6;
             border-radius: 6px;
-            padding: 16px;
-            margin-bottom: 16px;
+            padding: 8px;
+            margin-bottom: 8px;
             box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
         }
 
@@ -171,7 +171,7 @@
 
         .main-layout {
             display: flex;
-            gap: 20px;
+            gap: 12px;
             flex: 1;
             min-height: 0;
         }
@@ -179,18 +179,18 @@
         .board-container-wrapper {
             display: flex;
             flex-direction: column;
-            gap: 12px;
+            gap: 8px;
         }
 
         .board-section {
             background: white;
             border: 1px solid #dee2e6;
             border-radius: 6px;
-            padding: 16px;
+            padding: 8px;
             box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
             display: flex;
-            justify-content: center;
-            align-items: center;
+            justify-content: flex-start;
+            align-items: flex-start;
         }
 
         .game-status-compact {
@@ -233,7 +233,7 @@
             min-width: 450px;
             display: flex;
             flex-direction: column;
-            gap: 16px;
+            gap: 8px;
         }
 
         .analysis-panel {
@@ -353,7 +353,8 @@
             border: 1px solid #333;
             border-radius: 6px;
             padding: 12px;
-            margin-bottom: 16px;
+            margin-bottom: 8px;
+            width: 100%;
             box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
         }
 
@@ -670,44 +671,7 @@
 </head>
 <body>
     <div class="container">
-        <!-- Título -->
-        <div class="header">
-            <h1>Analizador de Ajedrez con Adaptación Dinámica</h1>
-        </div>
 
-        <!-- Input FEN y controles principales -->
-        <div class="input-section">
-            <div class="input-row">
-                <div class="input-group">
-                    <label for="fenInput">
-                        <i class="fas fa-code"></i> Posición FEN:
-                    </label>
-                    <input type="text" 
-                           id="fenInput" 
-                           value="rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-                           placeholder="Ingresa la posición FEN" 
-                           onclick="this.select()">
-                </div>
-                <div class="input-group" style="max-width: 200px;">
-                    <label for="modeSelect">
-                        <i class="fas fa-gamepad"></i> Modo:
-                    </label>
-                    <select id="modeSelect">
-                        <option value="edit">Edición</option>
-                        <option value="human">Humano vs Humano</option>
-                        <option value="cpu">Versus CPU</option>
-                    </select>
-                </div>
-                <div class="button-group">
-                    <button onclick="drawBoard()" class="btn btn-primary">
-                        <i class="fas fa-chess-board"></i> Cargar Posición
-                    </button>
-                    <button onclick="showLegalMoves()" id="showMovesBtn" class="btn btn-success">
-                        <i class="fas fa-list"></i> Movimientos
-                    </button>
-                </div>
-            </div>
-        </div>
 
         <!-- Layout principal -->
         <div class="main-layout">
@@ -731,6 +695,40 @@
 
             <!-- Panel derecho -->
             <div class="right-panel">
+                <!-- Input FEN y controles principales -->
+                <div class="input-section">
+                    <div class="input-row">
+                        <div class="input-group">
+                            <label for="fenInput">
+                                <i class="fas fa-code"></i> Posición FEN:
+                            </label>
+                            <input type="text"
+                                   id="fenInput"
+                                   value="rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+                                   placeholder="Ingresa la posición FEN"
+                                   onclick="this.select()">
+                        </div>
+                        <div class="input-group" style="max-width: 200px;">
+                            <label for="modeSelect">
+                                <i class="fas fa-gamepad"></i> Modo:
+                            </label>
+                            <select id="modeSelect">
+                                <option value="edit">Edición</option>
+                                <option value="human">Humano vs Humano</option>
+                                <option value="cpu">Versus CPU</option>
+                            </select>
+                        </div>
+                        <div class="button-group">
+                            <button onclick="drawBoard()" class="btn btn-primary">
+                                <i class="fas fa-chess-board"></i> Cargar Posición
+                            </button>
+                            <button onclick="showLegalMoves()" id="showMovesBtn" class="btn btn-success">
+                                <i class="fas fa-list"></i> Movimientos
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Logs de Adaptación -->
                 <div class="logs-section">
                     <div class="logs-header">


### PR DESCRIPTION
## Summary
- movida la sección FEN al panel derecho y eliminado el título
- reducido márgenes en contenedores y secciones
- alineado el tablero al extremo superior izquierdo
- los logs ahora ocupan todo el ancho del panel derecho

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c7625578c832db28952438d545e48