### PR TITLE
Increase adaptive analysis max depth to 25

### DIFF
--- a/index.html
+++ b/index.html
@@ -2204,7 +2204,7 @@
             const distance = Math.abs(currentEval);
             
             const EQUILIBRIUM_THRESHOLD = 25;
-            const MAX_DEPTH = 15;
+            const MAX_DEPTH = 25;
             const MIN_DEPTH = 1;
             const DEPTH_STEP = 1;
             const ITERATION_DELAY = 600;


### PR DESCRIPTION
## Summary
- raise adaptive analysis maximum depth constant from 15 to 25 plies to allow deeper search

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692112a80258832d871e5c47fd06e90e)