### PR TITLE
Reorganize FEN and logs layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,6 +245,29 @@
             display: flex;
             flex-direction: column;
             gap: 8px;
+            flex: 1;
+            min-height: 0;
+        }
+        .fen-logs-row {
+            display: flex;
+            align-items: stretch;
+            gap: 8px;
+            margin-bottom: 0;
+            flex-wrap: wrap;
+            min-height: 0;
+            flex: 1;
+        }
+        .fen-logs-row .input-section {
+            flex: 1.25;
+            min-width: 300px;
+            margin-bottom: 0;
+        }
+        .logs-column {
+            flex: 1;
+            min-width: 280px;
+            display: flex;
+            flex-direction: column;
+            min-height: 0;
         }
         .analysis-panel {
             background: white;
@@ -347,9 +370,12 @@
             border: 1px solid #dee2e6;
             border-radius: 6px;
             padding: 12px;
-            margin-bottom: 8px;
             width: 100%;
             box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+            display: flex;
+            flex-direction: column;
+            flex: 1;
+            min-height: 0;
         }
         .logs-header {
             display: flex;
@@ -388,13 +414,15 @@
             font-family: 'Courier New', monospace;
             font-size: 0.75rem;
             line-height: 1.4;
-            height: 180px;
             overflow-y: auto;
             background: #ffffff;
             color: #000000;
             padding: 8px;
             border-radius: 4px;
             border: 1px solid #dee2e6;
+            flex: 1;
+            max-height: calc(100vh - 220px);
+            min-height: 0;
         }
         .log-entry {
             display: flex;
@@ -644,54 +672,58 @@
                 </div>
             </div>
             <div class="right-panel">
-                <div class="input-section">
-                    <div class="input-row">
-                        <div class="input-group">
-                            <label for="fenInput">
-                                <i class="fas fa-code"></i> Posición FEN:
-                            </label>
-                            <input type="text"
-                                   id="fenInput"
-                                   value="rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-                                   placeholder="Ingresa la posición FEN"
-                                   onclick="this.select()">
-                        </div>
-                        <div class="input-group" style="max-width: 200px;">
-                            <label for="modeSelect">
-                                <i class="fas fa-gamepad"></i> Modo:
-                            </label>
-                            <select id="modeSelect">
-                                <option value="edit">Edición y análisis</option>
-                                <option value="human">Humano vs Humano</option>
-                                <option value="cpu">Versus CPU</option>
-                            </select>
-                        </div>
-                        <div class="button-group">
-                            <button onclick="drawBoard()" class="btn btn-primary">
-                                <i class="fas fa-chess-board"></i> Cargar Posición
-                            </button>
-                            <button onclick="showLegalMoves()" id="showMovesBtn" class="btn btn-success">
-                                <i class="fas fa-list"></i> Movimientos
-                            </button>
-                        </div>
-                    </div>
-                </div>
-                <div class="logs-section">
-                    <div class="logs-header">
-                        <div class="logs-title">
-                            <i class="fas fa-terminal"></i>
-                            Logs de Adaptación
-                        </div>
-                        <div class="logs-controls">
-                            <button onclick="clearLogs()" title="Limpiar logs">
-                                <i class="fas fa-trash"></i>
-                            </button>
-                            <button onclick="toggleLogsPause()" id="pauseLogsBtn" title="Pausar logs">
-                                <i class="fas fa-pause"></i>
-                            </button>
+                <div class="fen-logs-row">
+                    <div class="input-section">
+                        <div class="input-row">
+                            <div class="input-group">
+                                <label for="fenInput">
+                                    <i class="fas fa-code"></i> Posición FEN:
+                                </label>
+                                <input type="text"
+                                       id="fenInput"
+                                       value="rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+                                       placeholder="Ingresa la posición FEN"
+                                       onclick="this.select()">
+                            </div>
+                            <div class="input-group" style="max-width: 200px;">
+                                <label for="modeSelect">
+                                    <i class="fas fa-gamepad"></i> Modo:
+                                </label>
+                                <select id="modeSelect">
+                                    <option value="edit">Edición y análisis</option>
+                                    <option value="human">Humano vs Humano</option>
+                                    <option value="cpu">Versus CPU</option>
+                                </select>
+                            </div>
+                            <div class="button-group">
+                                <button onclick="drawBoard()" class="btn btn-primary">
+                                    <i class="fas fa-chess-board"></i> Cargar Posición
+                                </button>
+                                <button onclick="showLegalMoves()" id="showMovesBtn" class="btn btn-success">
+                                    <i class="fas fa-list"></i> Movimientos
+                                </button>
+                            </div>
                         </div>
                     </div>
-                    <div class="logs-container" id="logsContainer"></div>
+                    <div class="logs-column">
+                        <div class="logs-section">
+                            <div class="logs-header">
+                                <div class="logs-title">
+                                    <i class="fas fa-terminal"></i>
+                                    Logs de Adaptación
+                                </div>
+                                <div class="logs-controls">
+                                    <button onclick="clearLogs()" title="Limpiar logs">
+                                        <i class="fas fa-trash"></i>
+                                    </button>
+                                    <button onclick="toggleLogsPause()" id="pauseLogsBtn" title="Pausar logs">
+                                        <i class="fas fa-pause"></i>
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="logs-container" id="logsContainer"></div>
+                        </div>
+                    </div>
                 </div>
                 <div class="analysis-panel">
                     <div class="analysis-section">


### PR DESCRIPTION
## Summary
- wrap the FEN input form and logs panel in a shared flex row to place logs beside the form
- update flex rules so the right panel and logs area can expand vertically with the viewport height
- retain the existing analysis and moves panels beneath the combined FEN/logs block

## Testing
- Manual check in browser


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69211d79c010832d8434c860a281c07b)