### PR TITLE
Evita superposición de resultados en análisis y movimientos legales

### DIFF
--- a/index.html
+++ b/index.html
@@ -679,6 +679,17 @@ function resetAnalysisDisplay() {
     document.getElementById('engineStats').textContent = '--';
     document.getElementById('pvLine').textContent = 'Inicia el análisis para ver la mejor línea';
 }
+
+function prepareAnalysisOutput() {
+    const pvLine = document.getElementById('pvLine');
+    if (pvLine) {
+        pvLine.textContent = 'Analizando...';
+        pvLine.scrollTop = 0;
+    }
+    document.getElementById('evaluation').textContent = '--';
+    document.getElementById('bestMove').textContent = '--';
+    document.getElementById('engineStats').textContent = '--';
+}
 function resetHighlights() {
     previousHighlightedSquares.forEach(sq => sq.classList.remove('square-highlight', 'dark'));
     previousHighlightedSquares = [];
@@ -725,6 +736,7 @@ function highlightBestLine() {
 
 function toggleAnalysis() {
     if (isAnalyzing) { stopAnalysis(); return; }
+    prepareAnalysisOutput();
     // === INTEGRACIÓN RAMSEY: Filtro pre-análisis ===
     runRamseyFilter();
     const esc = analyzeEscape(board, chess.turn() === 'w' ? 'black' : 'white');
@@ -1013,7 +1025,8 @@ function showLegalMoves() {
     const moves = chess.moves({ verbose: true });
     const movesList = document.getElementById('legalMovesList');
     const movesHeader = document.getElementById('legalMovesHeader');
-    movesList.innerHTML = '';
+    movesList.replaceChildren();
+    movesList.scrollTop = 0;
     movesHeader.innerHTML = `<i class="fas fa-chess-knight"></i> Movimientos Legales (${moves.length})`;
     if (moves.length === 0) {
         movesList.innerHTML = '<div style="text-align:center;padding:20px;color:#6c757d;">No hay movimientos legales</div>';


### PR DESCRIPTION
### Motivation
- Evitar que los resultados nuevos de análisis o la lista de movimientos legales se mezclen visualmente con resultados previos al tocar los botones correspondientes.

### Description
- Agrega la función `prepareAnalysisOutput()` que limpia la evaluación, la mejor jugada, las estadísticas y muestra `pvLine` como `Analizando...` antes de iniciar un nuevo análisis.
- Llama a `prepareAnalysisOutput()` al inicio de `toggleAnalysis()` para garantizar un panel limpio al pulsar **Analizar**.
- En `showLegalMoves()` reemplaza `movesList.innerHTML = ''` por `movesList.replaceChildren()` y reinicia `movesList.scrollTop = 0` para evitar solapamientos y asegurar que el listado se muestre desde el inicio.

### Testing
- Ejecutados comandos de verificación del repositorio: `git diff -- index.html`, `git status --short`, y `git show --stat --oneline -1`, todos completados correctamente.
- Revisión manual del diff para asegurar que los cambios afectan únicamente la salida UI (no hay pruebas automatizadas unitarias en este despliegue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2b34efc8832d874e81036ecfb395)