### PR TITLE
Default to infinite-depth analysis on “Analizar” and improve analysis logs

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
                             </div>
                             <div id="engineStatus" class="engine-status">Motor no conectado</div>
                             <div class="adaptive-config">
-                                <label id="adaptiveLabel"><input type="checkbox" id="adaptiveToggle" checked><span>Modo adaptativo</span></label>
+                                <label id="adaptiveLabel"><input type="checkbox" id="adaptiveToggle"><span>Modo adaptativo</span></label>
                             </div>
                         </div>
                         <div class="analysis-section">
@@ -240,7 +240,7 @@
                 <div class="logs-column">
                     <div class="logs-section">
                         <div class="logs-header">
-                            <div class="logs-title"><i class="fas fa-terminal"></i> Logs de Adaptación</div>
+                            <div class="logs-title"><i class="fas fa-terminal"></i> Logs de Análisis</div>
                             <div class="logs-controls">
                                 <button onclick="clearLogs()" title="Limpiar logs"><i class="fas fa-trash"></i></button>
                                 <button onclick="toggleLogsPause()" id="pauseLogsBtn" title="Pausar logs"><i class="fas fa-pause"></i></button>
@@ -736,6 +736,7 @@ function highlightBestLine() {
 
 function toggleAnalysis() {
     if (isAnalyzing) { stopAnalysis(); return; }
+    addLog('info', 'Inicio de análisis solicitado desde el botón "Analizar"');
     prepareAnalysisOutput();
     // === INTEGRACIÓN RAMSEY: Filtro pre-análisis ===
     runRamseyFilter();
@@ -813,11 +814,11 @@ function startStandardAnalysis() {
     stockfish.postMessage(`position fen ${fen}`);
     stockfish.postMessage('go infinite');
     isAnalyzing = true;
-    document.getElementById('engineStatus').textContent = 'Análisis estándar en progreso...';
+    document.getElementById('engineStatus').textContent = 'Análisis estándar en progreso (profundidad infinita)...';
     document.getElementById('engineStatus').style.borderLeftColor = '#007bff';
     updateButtonStates();
     document.getElementById('pvLine').textContent = 'Analizando...';
-    addLog('info', 'Análisis estándar iniciado');
+    addLog('info', 'Análisis estándar iniciado en profundidad infinita');
 }
 
 function forceBestMove() {


### PR DESCRIPTION
### Motivation
- Facilitar que al pulsar `Analizar` se realice un análisis estándar en profundidad infinita (`go infinite`) en lugar de iniciar por defecto la búsqueda adaptativa.

### Description
- Desactivo por defecto el checkbox `adaptiveToggle` para que el flujo por defecto vaya a `startStandardAnalysis` y ejecute `go infinite`.
- Añado un registro cuando se solicita el análisis desde el botón (`toggleAnalysis`) y actualizo el texto de estado para indicar explícitamente "profundidad infinita" durante el análisis estándar.
- Renombro el título del panel de logs a "Logs de Análisis" para reflejar que los mensajes mostrados corresponden al proceso de análisis.

### Testing
- Verificación estática del archivo con búsquedas de texto (`rg`) y revisión de las líneas afectadas para confirmar `adaptiveToggle` desactivado, el mensaje de inicio de análisis y la cadena "profundidad infinita" presentes.
- No existe suite de tests automatizados en este repositorio; los cambios fueron validados mediante inspección de código y comprobaciones manuales de las cadenas y comportamientos visibles en `index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2e3bafc8832da2245db6288b0025)