### PR TITLE
Replace disputed overlay dashed border with pulsing SMIL indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,7 +454,12 @@ function generateChessboardSVG() {
             const r = Math.floor(sq / 8), c = sq % 8;
             const vy = (7 - r) * squareSize + 20;
             const vx = c * squareSize + 20;
-            svg += `<rect x="${vx + 2}" y="${vy + 2}" width="${squareSize - 4}" height="${squareSize - 4}" fill="none" stroke="#e74c3c" stroke-width="3" stroke-dasharray="4,2" pointer-events="none" />`;
+            const cx = vx + squareSize / 2;
+            const cy = vy + squareSize / 2;
+            svg += `<circle cx="${cx}" cy="${cy}" r="10" fill="#e74c3c" opacity="0.25" pointer-events="none">
+    <animate attributeName="r" values="6;20;6" dur="1.4s" repeatCount="indefinite" calcMode="easeInOut" />
+    <animate attributeName="opacity" values="0.15;0.45;0.15" dur="1.4s" repeatCount="indefinite" calcMode="easeInOut" />
+</circle>`;
         });
     }
     // Last move highlight


### PR DESCRIPTION
### Motivation
- Make disputed-square overlays more visible and dynamic by replacing the static dashed red rectangle with a self-contained pulsing indicator.
- Avoid relying on external CSS by using inline SMIL animations inside the generated SVG.

### Description
- In `generateChessboardSVG()` (`index.html`) removed the dashed `<rect>` marker used for `lastRamseyResult.disputed` squares and added a centered `<circle>` per disputed square.
- Compute `cx`/`cy` from the square position and insert a circle with `pointer-events="none"` so it does not block board interaction.
- Add two inline SMIL animations on the circle: `r` with `values="6;20;6"` and `opacity` with `values="0.15;0.45;0.15"`, both using `dur="1.4s"` and `repeatCount="indefinite"`.

### Testing
- Located the target snippet with `rg` which succeeded and verified the presence of `generateChessboardSVG` and the old `stroke-dasharray` line.
- Applied the automated replacement script (Python) which returned `updated` indicating the substitution completed successfully.
- Inspected changes with `git diff -- index.html` and `git status --short` which showed the modification, and `git commit` completed successfully creating the change in `index.html`.
- Created the PR metadata via the `make_pr` helper which produced the PR title and body, and that operation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee31e50bb8832daee89afaad5cc453)