### PR TITLE
Ajusta alto de la sección de evaluación en el panel de análisis

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,18 +72,19 @@
         .logs-column { flex: 1; min-width: 280px; display: flex; flex-direction: column; min-height: 0; }
         .analysis-inline { margin-top: 12px; padding-top: 12px; border-top: 1px solid #e9ecef; display: flex; flex-direction: column; gap: 12px; }
         .analysis-section { margin-bottom: 16px; padding-bottom: 16px; border-bottom: 1px solid #e9ecef; }
+        .analysis-section.evaluation-section { margin-bottom: 8px; padding-bottom: 8px; }
         .analysis-section:last-child { margin-bottom: 0; padding-bottom: 0; border-bottom: none; }
         .section-title { font-weight: 600; color: #495057; font-size: .875rem; margin-bottom: 8px; display: flex; align-items: center; gap: 6px; }
         .engine-controls { display: flex; gap: 8px; margin-bottom: 8px; flex-wrap: wrap; }
         .engine-controls .btn { flex: 1; min-width: 120px; }
         .engine-status { font-size: .8125rem; color: #6c757d; margin-bottom: 8px; padding: 6px 8px; background: #f8f9fa; border-radius: 4px; border-left: 3px solid #007bff; }
-        .evaluation-display { display: flex; align-items: center; gap: 12px; margin-bottom: 8px; }
+        .evaluation-display { display: flex; align-items: center; gap: 12px; margin-bottom: 6px; }
         .evaluation { font-weight: 600; font-size: 1.125rem; padding: 4px 8px; border-radius: 4px; min-width: 80px; text-align: center; border: 1px solid #dee2e6; }
         .eval-positive { color: #155724; background: #d4edda; border-color: #c3e6cb; }
         .eval-negative { color: #721c24; background: #f8d7da; border-color: #f5c6cb; }
         .eval-neutral { color: #495057; background: #e9ecef; border-color: #ced4da; }
         .best-move { font-weight: 500; color: #007bff; font-size: .875rem; flex: 1; }
-        .stats-display { display: flex; justify-content: space-between; font-size: .75rem; color: #6c757d; margin-bottom: 8px; gap: 8px; }
+        .stats-display { display: flex; justify-content: space-between; font-size: .75rem; color: #6c757d; margin-bottom: 0; gap: 8px; }
         .stats-display > span { flex: 1; text-align: center; padding: 4px 6px; background: #f8f9fa; border-radius: 4px; }
         .logs-section { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; padding: 12px; width: 100%; box-shadow: 0 1px 2px rgba(0,0,0,.1); display: flex; flex-direction: column; flex: 1; min-height: 0; }
         .logs-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; padding-bottom: 8px; border-bottom: 1px solid #dee2e6; }
@@ -273,7 +274,7 @@
                                 <label id="adaptiveLabel"><input type="checkbox" id="adaptiveToggle"><span>Modo adaptativo</span></label>
                             </div>
                         </div>
-                        <div class="analysis-section">
+                        <div class="analysis-section evaluation-section">
                             <div class="section-title"><i class="fas fa-balance-scale"></i> Evaluación Stockfish</div>
                             <div class="evaluation-display">
                                 <span id="evaluation" class="evaluation">--</span>


### PR DESCRIPTION
### Motivation
- La caja de la evaluación (bloque “Evaluación Stockfish”) ocupaba demasiado alto y dejaba espacio vertical sin uso, por lo que se compacta para mejorar la densidad visual del panel derecho.

### Description
- Se añadió `.analysis-section.evaluation-section` con `margin-bottom: 8px; padding-bottom: 8px`, se redujo `margin-bottom` de `.evaluation-display` a `6px` y de `.stats-display` a `0`, y se aplicó la clase `evaluation-section` al contenedor de la evaluación en `index.html`.

### Testing
- Se inspeccionó localmente el diff y el contenido de `index.html` para confirmar que las reglas CSS y la clase se aplicaron correctamente; no se ejecutaron pruebas visuales automatizadas por ausencia de entorno de navegador en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3d110218832d9f9e6501b1da97e5)