### PR TITLE
Mostrar overlays Ramsey al analizar y dibujar flechas de escape de reyes

### DIFF
--- a/index.html
+++ b/index.html
@@ -501,6 +501,36 @@ function generateChessboardSVG() {
     }
     // Overlays Ramsey (opcionales)
     if (ramseyOverlays && lastEscapeAnalysis) {
+        svg += `<defs>
+            <marker id="ramseyArrowWhite" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+                <polygon points="0 0, 9 4.5, 0 9" fill="#ffffff" />
+            </marker>
+            <marker id="ramseyArrowBlack" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+                <polygon points="0 0, 9 4.5, 0 9" fill="#000000" />
+            </marker>
+        </defs>`;
+        const drawEscapeArrows = (analysis, isWhiteKing) => {
+            if (!analysis || typeof analysis.kingPos !== 'number') return;
+            const kRow = Math.floor(analysis.kingPos / 8);
+            const kCol = analysis.kingPos % 8;
+            const kx = kCol * squareSize + squareSize / 2 + 20;
+            const ky = (7 - kRow) * squareSize + squareSize / 2 + 20;
+            const movesToDraw = analysis.safe.size > 0 ? analysis.safe : analysis.escapes;
+            movesToDraw.forEach(sq => {
+                const row = Math.floor(sq / 8);
+                const col = sq % 8;
+                const tx = col * squareSize + squareSize / 2 + 20;
+                const ty = (7 - row) * squareSize + squareSize / 2 + 20;
+                if (tx === kx && ty === ky) return;
+                const strokeColor = isWhiteKing ? '#ffffff' : '#000000';
+                const marker = isWhiteKing ? 'ramseyArrowWhite' : 'ramseyArrowBlack';
+                const outline = isWhiteKing ? '#000000' : '#ffffff';
+                svg += `<line x1="${kx}" y1="${ky}" x2="${tx}" y2="${ty}" stroke="${outline}" stroke-width="4" opacity="0.75" pointer-events="none" />`;
+                svg += `<line x1="${kx}" y1="${ky}" x2="${tx}" y2="${ty}" stroke="${strokeColor}" stroke-width="2.4" opacity="0.92" marker-end="url(#${marker})" pointer-events="none" />`;
+            });
+        };
+        drawEscapeArrows(lastEscapeAnalysis.white, true);
+        drawEscapeArrows(lastEscapeAnalysis.black, false);
         if (lastEscapeAnalysis.white) {
             lastEscapeAnalysis.white.safe.forEach(sq => {
                 const r = Math.floor(sq / 8), c = sq % 8;
@@ -828,11 +858,11 @@ function toggleAnalysis() {
     prepareAnalysisOutput();
     // === INTEGRACIÓN RAMSEY: Filtro pre-análisis ===
     runRamseyFilter();
-    const esc = analyzeEscape(board, chess.turn() === 'w' ? 'black' : 'white');
-    lastEscapeAnalysis = esc;
+    refreshEscapeAnalysis();
+    const esc = chess.turn() === 'w' ? lastEscapeAnalysis.black : lastEscapeAnalysis.white;
+    ramseyOverlays = true;
+    updateBoard();
     if (esc && esc.score >= 95) {
-        ramseyOverlays = true;
-        updateBoard();
         addLog('warning', '⚠ Ramsey: Mate estructural detectado. Búsqueda profunda omitida.');
         document.getElementById('engineStatus').textContent = 'Mate estructural (Ramsey) — Motor no requerido';
         document.getElementById('engineStatus').style.borderLeftColor = '#c0392b';
@@ -849,8 +879,7 @@ function toggleAnalysis() {
 // Botón independiente para ejecutar solo Ramsey
 function runRamseyOnly() {
     runRamseyFilter();
-    const esc = analyzeEscape(board, chess.turn() === 'w' ? 'black' : 'white');
-    lastEscapeAnalysis = esc;
+    refreshEscapeAnalysis();
     ramseyOverlays = true;
     updateBoard();
     addLog('ramsey', 'Filtro Ramsey ejecutado manualmente');
@@ -1236,6 +1265,12 @@ function setRamseyMode(mode) {
     }
     updateBoard();
     addLog('ramsey', `Modo Ramsey: ${ramseyMode === 'heatmap' ? 'Heatmap' : 'Choque global'}`);
+}
+
+function refreshEscapeAnalysis() {
+    const escW = analyzeEscape(board, 'white');
+    const escB = analyzeEscape(board, 'black');
+    lastEscapeAnalysis = { white: escW, black: escB, turn: chess ? chess.turn() : 'w' };
 }
 
 // ===================== FUNCIONES INTERNAS DEL MOTOR RAMSEY =====================


### PR DESCRIPTION
### Motivation
- El filtro Ramsey calculaba valores pero no activaba sus overlays visuales ni mostraba las rutas de escape cuando se pulsaba `Analizar`, por lo que el usuario no veía los círculos pulsantes ni las rutas de escape en el tablero.
- Se requiere indicar visualmente las casillas de escape y movimientos de escape para ambos reyes con flechas claras y contrastadas desde la casilla del rey hasta las casillas destino.

### Description
- En `generateChessboardSVG` se añadieron dos `marker` SVG (`ramseyArrowWhite` y `ramseyArrowBlack`) y se implementó el trazado de flechas de escape con contorno para ambos reyes, dibujando primero una línea de contorno y luego la línea coloreada con `marker-end`. 
- Se añadió el dibujo de flechas que parten de la casilla del rey hacia sus casillas seguras (o, si no hay, hacia las casillas de escape) y se conservaron los círculos indicativos de casillas seguras/disputadas de Ramsey. 
- Se creó `refreshEscapeAnalysis()` que calcula y normaliza `lastEscapeAnalysis` para ambos bandos, y se integró en `toggleAnalysis()` y `runRamseyOnly()` para activar `ramseyOverlays = true` y forzar la actualización del tablero justo al pulsar `Analizar` o el botón de Ramsey. 

### Testing
- Se ejecutaron comprobaciones estáticas y de coherencia en el árbol de trabajo (`git diff --check` y escaneos de referencias con `rg`) y no se reportaron errores en el archivo modificado. 
- Se inspeccionó el fichero `index.html` para verificar la inserción de los `marker`, la nueva función `refreshEscapeAnalysis()` y las llamadas desde `toggleAnalysis()` y `runRamseyOnly()`, confirmando referencias encontradas por `rg`. 
- No se ejecutaron pruebas de interfaz gráficas automatizadas en navegador en este entorno, por lo que la verificación visual final debe realizarse en un navegador real para confirmar la apariencia de flechas y overlays en distintas posiciones del tablero.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3fd00060832dbdd3c5a4ed8bcc87)