### PR TITLE
Ajustar colores de flechas de escape en overlay Ramsey

### DIFF
--- a/index.html
+++ b/index.html
@@ -503,10 +503,10 @@ function generateChessboardSVG() {
     if (ramseyOverlays && lastEscapeAnalysis) {
         svg += `<defs>
             <marker id="ramseyArrowWhite" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
-                <polygon points="0 0, 9 4.5, 0 9" fill="#ffffff" />
+                <polygon points="0 0, 9 4.5, 0 9" fill="#2980b9" />
             </marker>
             <marker id="ramseyArrowBlack" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
-                <polygon points="0 0, 9 4.5, 0 9" fill="#000000" />
+                <polygon points="0 0, 9 4.5, 0 9" fill="#e74c3c" />
             </marker>
         </defs>`;
         const drawEscapeArrows = (analysis, isWhiteKing) => {
@@ -522,7 +522,7 @@ function generateChessboardSVG() {
                 const tx = col * squareSize + squareSize / 2 + 20;
                 const ty = (7 - row) * squareSize + squareSize / 2 + 20;
                 if (tx === kx && ty === ky) return;
-                const strokeColor = isWhiteKing ? '#ffffff' : '#000000';
+                const strokeColor = isWhiteKing ? '#2980b9' : '#e74c3c';
                 const marker = isWhiteKing ? 'ramseyArrowWhite' : 'ramseyArrowBlack';
                 const outline = isWhiteKing ? '#000000' : '#ffffff';
                 svg += `<line x1="${kx}" y1="${ky}" x2="${tx}" y2="${ty}" stroke="${outline}" stroke-width="4" opacity="0.75" pointer-events="none" />`;


### PR DESCRIPTION
### Motivation
- Alinear la codificación visual de las flechas de escape del filtro Ramsey para que las rutas de las piezas blancas sean azules y las de las negras rojas.

### Description
- Actualicé `index.html` para que los `marker` de las flechas usen `fill="#2980b9"` (ramseyArrowWhite) y `fill="#e74c3c"` (ramseyArrowBlack), y ajusté `strokeColor` en `drawEscapeArrows` a `'#2980b9'` para blancas y `'#e74c3c'` para negras.

### Testing
- Verifiqué el estado del repositorio con `git -C /workspace/ajedrez status --short` y confirmé el commit con `git -C /workspace/ajedrez add index.html && git -C /workspace/ajedrez commit -m "Ajusta colores de flechas de escape Ramsey"`, ambos comandos completados correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee416a3be0832dba7068eb74882966)