### PR TITLE
Mantener flecha del motor (best-move) cuando las flechas Ramsey están activas

### DIFF
--- a/index.html
+++ b/index.html
@@ -489,6 +489,9 @@ function formatEvaluation(score, isMate) {
 // ===================== GENERACIÓN DEL TABLERO SVG (CON OVERLAYS RAMSEY) =====================
 function generateChessboardSVG() {
     let svg = `<svg width="${boardSize + 40}" height="${boardSize + 40}" xmlns="http://www.w3.org/2000/svg">`;
+    const defs = [];
+    const hasBestMoveArrow = !!(lastStats.bestMove && lastStats.bestMove.length >= 4);
+    const hasRamseyEscapeArrows = !!(ramseyOverlays && lastEscapeAnalysis);
     // Casillas base
     for (let row = 0; row < 8; row++) {
         for (let col = 0; col < 8; col++) {
@@ -499,16 +502,24 @@ function generateChessboardSVG() {
             svg += `<rect x="${x}" y="${y}" width="${squareSize}" height="${squareSize}" fill="${fill}" data-square="${squareName}" onclick="handleSquareClick('${squareName}')" style="cursor:pointer;" />`;
         }
     }
-    // Overlays Ramsey (opcionales)
-    if (ramseyOverlays && lastEscapeAnalysis) {
-        svg += `<defs>
+    if (hasRamseyEscapeArrows) {
+        defs.push(`
             <marker id="ramseyArrowWhite" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
                 <polygon points="0 0, 9 4.5, 0 9" fill="#2980b9" />
             </marker>
             <marker id="ramseyArrowBlack" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
                 <polygon points="0 0, 9 4.5, 0 9" fill="#e74c3c" />
             </marker>
-        </defs>`;
+        `);
+    }
+    if (hasBestMoveArrow) {
+        defs.push(`<marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="#007bff"/></marker>`);
+    }
+    if (defs.length > 0) {
+        svg += `<defs>${defs.join('')}</defs>`;
+    }
+    // Overlays Ramsey (opcionales)
+    if (hasRamseyEscapeArrows) {
         const drawEscapeArrows = (analysis, isWhiteKing) => {
             if (!analysis || typeof analysis.kingPos !== 'number') return;
             const kRow = Math.floor(analysis.kingPos / 8);
@@ -610,7 +621,7 @@ function generateChessboardSVG() {
         }
     });
     // Best move arrow
-    if (lastStats.bestMove && lastStats.bestMove.length >= 4) {
+    if (hasBestMoveArrow) {
         const from = lastStats.bestMove.substring(0,2);
         const to = lastStats.bestMove.substring(2,4);
         const fromCol = from.charCodeAt(0) - 97;
@@ -621,7 +632,6 @@ function generateChessboardSVG() {
         const fromY = fromRow * squareSize + squareSize/2 + 20;
         const toX = toCol * squareSize + squareSize/2 + 20;
         const toY = toRow * squareSize + squareSize/2 + 20;
-        svg += `<defs><marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="#007bff"/></marker></defs>`;
         svg += `<line x1="${fromX}" y1="${fromY}" x2="${toX}" y2="${toY}" stroke="#007bff" stroke-width="3" opacity="0.8" marker-end="url(#arrowhead)" pointer-events="none" />`;
     }
     // Piezas
@@ -1043,6 +1053,8 @@ function handleEngineMessage(msg) {
         if (lastStats.bestMoveSan) {
             document.getElementById('bestMove').textContent = `Mejor: ${lastStats.bestMoveSan}`;
         }
+        // La flecha del motor debe persistir incluso cuando las flechas Ramsey están activas.
+        updateBoard();
         updateButtonStates();
     } else if (msg.startsWith('info')) {
         parseInfoLine(msg);


### PR DESCRIPTION
### Motivation
- Evitar que el marcador/flecha calculada por el filtro Ramsey suprima o reemplace la flecha del mejor movimiento calculada por el motor, porque representan conceptos distintos y deben coexistir visualmente.

### Description
- Refactoricé `generateChessboardSVG()` para construir un único bloque `<defs>` y declarar dos banderas: `hasBestMoveArrow` y `hasRamseyEscapeArrows`, de modo que ambos marcadores (Ramsey y motor) se definan y se usen independientemente en el SVG.
- Cambié la lógica de renderizado para usar `defs.push(...)` y `defs.join('')` y así evitar definiciones duplicadas o condiciones que ocultaban una flecha por la otra.
- Forcé un repintado del tablero llamando a `updateBoard()` al procesar el mensaje `bestmove` en `handleEngineMessage()` para asegurar que la flecha del motor aparezca inmediatamente incluso si las overlays Ramsey ya están activas.
- Archivo modificado: `index.html`.

### Testing
- Ejecuté `git diff --check` para verificar que no hubiera errores de formato y la comprobación devolvió éxito.
- El cambio fue agregado y confirmado en un commit con el mensaje `Preserve engine best-move arrow alongside Ramsey escape arrows`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee42eb54b8832dbf6fd0dc65c8941b)