### PR TITLE
Reubica “Mejor línea de juego” bajo el indicador de turno

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,6 +238,10 @@
                 </div>
             </div>
             <div id="gameStatus" class="game-status-compact status-info"><i class="fas fa-info-circle"></i><span>Cargando...</span></div>
+            <div class="pv-section-main">
+                <div class="pv-title"><i class="fas fa-route"></i> Mejor línea de juego:</div>
+                <div id="pvLine" class="pv-line-main">Inicia el análisis para ver la mejor línea</div>
+            </div>
         </div>
         <div class="right-panel">
             <div class="fen-logs-row">
@@ -317,10 +321,6 @@
                         <div class="logs-container" id="logsContainer"></div>
                     </div>
                 </div>
-            </div>
-            <div class="pv-section-main">
-                <div class="pv-title"><i class="fas fa-route"></i> Mejor línea de juego:</div>
-                <div id="pvLine" class="pv-line-main">Inicia el análisis para ver la mejor línea</div>
             </div>
             <div id="legalMoves" class="moves-panel" style="display:none;">
                 <div class="moves-header">


### PR DESCRIPTION
### Motivation
- Mostrar la sección de la mejor línea (`pv-section-main`) inmediatamente debajo del indicador de turno (`#gameStatus`) para mejorar la correlación visual entre el turno activo y la línea de juego sugerida.

### Description
- Movido el bloque HTML `pv-section-main` que contiene `#pvLine` desde `.right-panel` a `.board-container-wrapper` justo después de `#gameStatus` en `index.html` sin cambiar IDs ni comportamiento JS.

### Testing
- Ejecutados los comandos `git -C /workspace/ajedrez diff -- index.html`, `git -C /workspace/ajedrez status --short` y `git -C /workspace/ajedrez commit`, y todos completaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee443e873c832d9cdba00f7d76f0d1)