### PR TITLE
Move Turán pruning to per-ply MB scan and expose prune metrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -926,21 +926,12 @@ function runMBDeepScan() {
         return;
     }
     const monitoredSide = chess.turn() === 'w' ? 'white' : 'black';
-    const boardArr = parseFENtoBoardArr(fen);
-    const controlData = buildControlData(boardArr);
-    const rivalGraph = monitoredSide === 'white' ? controlData.Gblack : controlData.Gwhite;
-    const turanCheck = evaluateTuranK4Prune(rivalGraph);
-    if (turanCheck.shouldPrune) {
-        addLog('info', `Poda de Turán: ${turanCheck.edgeCount} aristas detectadas. Umbral K4 es > ${turanCheck.turanLimit}.`);
-        addLog('ramsey', 'Estructura estable (Poda matemática aplicada).');
-        document.getElementById('scannerStatus').textContent = 'Poda de Turán activada: estructura sin K4 posible.';
-        return;
-    }
-    addLog('warning', `Densidad crítica detectada (${turanCheck.edgeCount} aristas). Iniciando búsqueda de cliques...`);
     const result = mbDeepScan(fen, pvMoves, monitoredSide);
     lastScannerResult = result;
     renderMBScanner(result);
-    addLog('ramsey', `MB-Scanner: ${result.scans.length} niveles escaneados en ${result.timeMs.toFixed(1)}ms`);
+    const prunedPlys = result.scans.filter(s => s.scan.turanPruned).length;
+    const totalPlys = result.scans.length;
+    addLog('ramsey', `MB-Scanner: ${totalPlys} niveles escaneados (${prunedPlys} podados por Turán) en ${result.timeMs.toFixed(1)}ms`);
 }
 
 function startEngineTurnIfNeeded() {
@@ -1559,7 +1550,8 @@ function scanPosition(boardArr, sideToMonitor) {
     const myKing = findKingSquare(boardArr, sideToMonitor);
     const rivalGraph = sideToMonitor === 'white' ? data.Gblack : data.Gwhite;
     const turanCheck = evaluateTuranK4Prune(rivalGraph);
-    const rivalK4 = turanCheck.shouldPrune ? [] : findCliques(rivalGraph, 4);
+    const turanPruned = turanCheck.shouldPrune;
+    const rivalK4 = turanPruned ? [] : findCliques(rivalGraph, 4);
     const rivalPieces = sideToMonitor === 'white' ? data.blackPieces : data.whitePieces;
     if (myKing) {
         const [kr, kc] = myKing;
@@ -1592,7 +1584,9 @@ function scanPosition(boardArr, sideToMonitor) {
         rivalMaxDanger: rivalVuln.maxDanger,
         k4NearMyKing: k4NearKing,
         crownDisputed,
-        totalDisputed: data.disputed.size
+        totalDisputed: data.disputed.size,
+        turanPruned,
+        turanEdgeCount: turanCheck.edgeCount
     };
 }
 


### PR DESCRIPTION
### Motivation
- Evitar que la poda de Turán en la raíz impida escanear la PV cuando la posición inicial parece tranquila pero la línea principal se vuelve táctica. 
- Mantener la poda a nivel de ply para ahorrar trabajo en plys de baja densidad mientras se reporta explícitamente cuándo ocurrió la poda. 

### Description
- Eliminé el gate de poda de Turán en la entrada de `runMBDeepScan` para que el escaneo profundo siempre recorra la PV y no retorne anticipadamente. 
- Añadí métricas agregadas al final de `runMBDeepScan` calculando `prunedPlys` y `totalPlys` y registrándolas en el log de `ramsey`. 
- En `scanPosition` expuse el flag `turanPruned` y `turanEdgeCount` y cambié la evaluación local a `const turanPruned = turanCheck.shouldPrune;` manteniendo la conducta de no buscar K4 cuando aplica poda. 

### Testing
- Ejecuté `git diff --check` sobre la copia del repositorio y no reportó errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb3907988832d92911bff43789f34)