### PR TITLE
UI: mover Conectar SF y unificar Ejecutar/Detener en un solo botón

### DIFF
--- a/index.html
+++ b/index.html
@@ -670,9 +670,8 @@
           <option value="combined-analysis">🧠 Análisis combinado</option>
         </select>
         <div class="action-buttons">
-          <button class="btn btn-primary" id="btn-execute-mode" onclick="executeCurrentMode()">▶ Ejecutar</button>
-          <button class="btn" id="btn-stop-action" onclick="stopAnyAnalysis()">⏹ Detener</button>
           <button class="btn" id="btn-connect-engine" onclick="connectStockfish()">🔌 Conectar SF</button>
+          <button class="btn btn-primary" id="btn-run-stop" onclick="handleRunStopAction()" disabled>▶ Ejecutar</button>
         </div>
         <div id="engine-status-text" style="font-size:11px; margin-top:6px; background:white; border:1px solid #808080; border-top-color:#404040; border-left-color:#404040; padding:3px 6px; font-family:'Courier New',monospace;">Motor: desconectado</div>
       </div>
@@ -822,6 +821,20 @@ function log(msg, type = 'info') {
   logArea.scrollTop = logArea.scrollHeight;
 }
 
+
+function updateRunStopButton() {
+  const runStopBtn = document.getElementById('btn-run-stop');
+  if (!runStopBtn) return;
+  runStopBtn.disabled = !state.stockfish.isConnected;
+  if (activeMode === 'idle') {
+    runStopBtn.textContent = '▶ Ejecutar';
+    runStopBtn.classList.add('btn-primary');
+  } else {
+    runStopBtn.textContent = '⏹ Detener';
+    runStopBtn.classList.remove('btn-primary');
+  }
+}
+
 // ============================================================
 // MAQUINA DE ESTADO — canStart / enterMode / exitMode
 // ============================================================
@@ -839,6 +852,7 @@ function enterMode(mode) {
   activeMode = mode;
   document.getElementById('status-engine').textContent = `Engine: ${MODE_LABELS[mode]}`;
   document.getElementById('status-engine').classList.add('active');
+  updateRunStopButton();
   log(`${MODE_LABELS[mode]} iniciado`, mode.startsWith('ramsey') ? 'ramsey' : 'info');
 }
 
@@ -849,6 +863,7 @@ function exitMode() {
   document.getElementById('status-engine').textContent = 'Engine: Standby';
   document.getElementById('status-engine').classList.remove('active');
   document.getElementById('status-ramsey').classList.remove('active', 'certified');
+  updateRunStopButton();
   if (prev !== 'idle') log(`${MODE_LABELS[prev]} finalizado`, 'info');
 }
 
@@ -2022,6 +2037,7 @@ async function connectStockfish() {
     log('Stockfish desconectado', 'info');
     updateEngineStatus('Motor: desconectado', '');
     document.getElementById('btn-connect-engine').textContent = '🔌 Conectar SF';
+    updateRunStopButton();
     return;
   }
   try {
@@ -2041,6 +2057,7 @@ async function connectStockfish() {
     log('Motor Stockfish conectado', 'success');
     updateEngineStatus('Motor: conectado ✓', 'connected');
     document.getElementById('btn-connect-engine').textContent = '🔌 Desconectar';
+    updateRunStopButton();
   } catch (error) {
     log('Error conectando motor: ' + error.message, 'warn');
     updateEngineStatus('Error: ' + error.message, 'error');
@@ -2302,6 +2319,7 @@ function startStockfishAnalysis() {
     state.stockfish.lastLines = [];
     updateEngineStatus('Stockfish analizando (go infinite)...', 'connected');
     document.getElementById('btn-connect-engine').disabled = true;
+    updateRunStopButton();
 
     const fen = currentFEN;
     state.stockfish.worker.postMessage('setoption name MultiPV value 1');
@@ -2343,6 +2361,16 @@ function stopAnyAnalysis() {
   }
   state.stockfish.busy = false;
   exitMode();
+}
+
+
+function handleRunStopAction() {
+  if (!state.stockfish.isConnected) {
+    log('Conecta Stockfish primero', 'warn');
+    return;
+  }
+  if (activeMode === 'idle') executeCurrentMode();
+  else stopAnyAnalysis();
 }
 
 // ============================================================
@@ -2428,6 +2456,7 @@ function init() {
   renderBoardSVG();
   updateHashDisplay();
   updateEvaluation(evaluateBoard(), getSignature(evaluateBoard()));
+  updateRunStopButton();
   log('RASP-FEN Windows95 Edition listo', 'info');
 }
 


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia en el panel de análisis colocando el control de conexión del motor a la izquierda y evitando acciones inválidas cuando Stockfish no esté conectado.
- Simplificar la interacción unificando los botones mutuamente excluyentes "Ejecutar" y "Detener" en un único control que refleje el estado actual.

### Description
- Reordené los controles en `index.html` para que el botón `🔌 Conectar SF` esté a la izquierda y reemplacé los botones separados `▶ Ejecutar` / `⏹ Detener` por un único botón `btn-run-stop` dinámico deshabilitado por defecto. 
- Añadí la función `updateRunStopButton()` que habilita/deshabilita y actualiza el texto/estilo del botón según `state.stockfish.isConnected` y `activeMode`.
- Integré llamadas a `updateRunStopButton()` en los puntos clave: `enterMode`, `exitMode`, `connectStockfish` (conectar/desconectar) y `startStockfishAnalysis`, y llamo a la función también durante `init()` para inicializar el estado del botón.
- Implementé `handleRunStopAction()` que actúa como único handler para ejecutar/detener: valida la conexión y llama a `executeCurrentMode()` o `stopAnyAnalysis()` según el estado.

### Testing
- Ejecuté `rg --files` para confirmar el árbol de archivos y la presencia de `index.html`, y la búsqueda devolvió resultados correctamente (éxito).
- Realicé búsquedas con `rg -n "Conectar|Desconectar|Ejecutar|Detener|connect|stop|start" index.html` para verificar los puntos de integración y las referencias actualizadas (éxito).
- Verifiqué el diff con `git diff -- index.html` y registré los cambios mediante `git commit` con el mensaje del cambio; ambas operaciones se completaron correctamente (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f55b9b575c832d881ea36868227ed9)